### PR TITLE
fix(ReactExoplayerView): disable audio focus

### DIFF
--- a/Video.js
+++ b/Video.js
@@ -321,6 +321,10 @@ export default class Video extends Component {
   }
 }
 
+Video.defaultProps = {
+  disableFocus: false
+};
+
 Video.propTypes = {
   filter: PropTypes.oneOf([
       FilterType.NONE,

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -139,7 +139,7 @@ class ReactExoplayerView extends FrameLayout implements
     private String textTrackType;
     private Dynamic textTrackValue;
     private ReadableArray textTracks;
-    private boolean disableFocus;
+    private boolean disableFocus = true;
     private float mProgressUpdateInterval = 250.0f;
     private boolean playInBackground = false;
     private Map<String, String> requestHeaders;
@@ -1098,6 +1098,7 @@ class ReactExoplayerView extends FrameLayout implements
 
     public void setDisableFocus(boolean disableFocus) {
         this.disableFocus = disableFocus;
+        requestAudioFocus();
     }
 
     public void setFullscreen(boolean fullscreen) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "4.4.1",
+    "version": "4.4.2",
     "description": "A <Video /> element for react-native",
     "main": "Video.js",
     "license": "MIT",


### PR DESCRIPTION
Fix when component initialize, the 'requestAudioFocus' method always request the focus to 'AudioManager' even when the property 'disableFocus' is passed by parameter.
The 'disableFocus' need to be started with 'true' value and a call to 'requestAudioFocus' inside the 'setDisableFocus' need to be perfom to update it.