### PR TITLE
fix(ReactExoplayerView): return unset track index when there are no t…

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -827,6 +827,10 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     private int getTrackIndexForDefaultLocale(TrackGroupArray groups) {
+        if (groups.length == 0) { // Avoid a crash if we try to select a non-existant group
+            return C.INDEX_UNSET;
+        }
+
         int trackIndex = 0; // default if no match
         String locale2 = Locale.getDefault().getLanguage(); // 2 letter code
         String locale3 = Locale.getDefault().getISO3Language(); // 3 letter code


### PR DESCRIPTION
…rack available

This fix was integrated on version 4.0.0. We need it in order to fix a problem
on Android, where the video freezes on the first frame when using a remote url
instead of an asset.

link to the upstream PR:
https://github.com/react-native-community/react-native-video/pull/1233

Thanks for opening a PR!
Since this is a volunteer project and is very active, anything you can do to reduce the amount of time needed to review and merge your PR is appreciated.
The following steps will help get your PR merged quickly:

#### Update the documentation
If you've added new functionality, update the README.md with an entry for your prop or event.
The entry should be inserted in alphabetical order.

#### Update the changelog
After you open the PR, update the CHANGELOG.md file with an entry pointing to your PR.

#### Provide an example of how to test the change
If the PR requires special testing setup provide all the relevant instructions and files. This may include a sample video file or URL, configuration, or setup steps.

#### Focus the PR on only one area
Testing multiple features takes longer than isolated changes and if there is a bug in one feature, prevents the other parts of your PR from getting merged until it gets fixed.
If you're touching multiple different areas that aren't related, break the changes up into multiple PRs.

#### Describe the changes
Add a note describing what your PR does. If there is a change to the behavior of the code, explain why it needs to be updated.
